### PR TITLE
Feature/chatbot/api-integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+# application.properties 무시
+src/main/resources/application.properties
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -12,7 +12,7 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 
 @EnableWebMvc
-@ComponentScan(basePackages = {"org.scoula.exception", "org.scoula.controller"})        // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
+@ComponentScan(basePackages = {"org.scoula"})        // Spring MVC용 컴포넌트 등록을 위한 스캔 패키지
 public class ServletConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/src/main/java/org/scoula/controller/chatbot/ChatBotController.java
+++ b/src/main/java/org/scoula/controller/chatbot/ChatBotController.java
@@ -1,0 +1,4 @@
+package org.scoula.controller.chatbot;
+
+public class ChatBotController {
+}

--- a/src/main/java/org/scoula/controller/chatbot/ChatBotController.java
+++ b/src/main/java/org/scoula/controller/chatbot/ChatBotController.java
@@ -1,4 +1,27 @@
 package org.scoula.controller.chatbot;
 
+import lombok.RequiredArgsConstructor;
+import org.scoula.domain.chatbot.dto.ChatRequestDto;
+import org.scoula.domain.chatbot.dto.ChatResponseDto;
+import org.scoula.service.chatbot.ChatBotService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
 public class ChatBotController {
+
+    private final ChatBotService chatBotService;
+
+    @PostMapping
+    public ResponseEntity<ChatResponseDto> chat(@RequestBody ChatRequestDto request) {
+        ChatResponseDto response = chatBotService.getChatResponse(request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/org/scoula/domain/chatbot/dto/ChatRequestDto.java
+++ b/src/main/java/org/scoula/domain/chatbot/dto/ChatRequestDto.java
@@ -1,0 +1,4 @@
+package org.scoula.domain.chatbot.dto;
+
+public class ChatRequestDto {
+}

--- a/src/main/java/org/scoula/domain/chatbot/dto/ChatRequestDto.java
+++ b/src/main/java/org/scoula/domain/chatbot/dto/ChatRequestDto.java
@@ -1,4 +1,13 @@
 package org.scoula.domain.chatbot.dto;
 
+import io.swagger.annotations.ApiModel;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description ="GPT 요청 DTO")
 public class ChatRequestDto {
+    private String message;
 }

--- a/src/main/java/org/scoula/domain/chatbot/dto/ChatResponseDto.java
+++ b/src/main/java/org/scoula/domain/chatbot/dto/ChatResponseDto.java
@@ -1,0 +1,4 @@
+package org.scoula.domain.chatbot.dto;
+
+public class ChatResponseDto {
+}

--- a/src/main/java/org/scoula/domain/chatbot/dto/ChatResponseDto.java
+++ b/src/main/java/org/scoula/domain/chatbot/dto/ChatResponseDto.java
@@ -1,4 +1,16 @@
 package org.scoula.domain.chatbot.dto;
 
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(discriminator = "GPT 응답 DTO")
 public class ChatResponseDto {
+    private String content;
 }

--- a/src/main/java/org/scoula/domain/chatbot/vo/ChatMessage.java
+++ b/src/main/java/org/scoula/domain/chatbot/vo/ChatMessage.java
@@ -1,0 +1,4 @@
+package org.scoula.domain.chatbot.vo;
+
+public class ChatMessage {
+}

--- a/src/main/java/org/scoula/mapper/ChatBotMapper.java
+++ b/src/main/java/org/scoula/mapper/ChatBotMapper.java
@@ -1,0 +1,4 @@
+package org.scoula.mapper;
+
+public class ChatBotMapper {
+}

--- a/src/main/java/org/scoula/service/chatbot/ChatBotService.java
+++ b/src/main/java/org/scoula/service/chatbot/ChatBotService.java
@@ -1,0 +1,4 @@
+package org.scoula.service.chatbot;
+
+public interface ChatBotService {
+}

--- a/src/main/java/org/scoula/service/chatbot/ChatBotService.java
+++ b/src/main/java/org/scoula/service/chatbot/ChatBotService.java
@@ -1,4 +1,12 @@
 package org.scoula.service.chatbot;
 
+
+import org.scoula.domain.chatbot.dto.ChatRequestDto;
+import org.scoula.domain.chatbot.dto.ChatResponseDto;
+import org.springframework.stereotype.Service;
+
+
 public interface ChatBotService {
+
+    ChatResponseDto getChatResponse(ChatRequestDto request);
 }

--- a/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
+++ b/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
@@ -1,0 +1,4 @@
+package org.scoula.service.chatbot;
+
+public class ChatBotServiceImpl extends ChatBotService{
+}

--- a/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
+++ b/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
@@ -1,4 +1,78 @@
 package org.scoula.service.chatbot;
 
-public class ChatBotServiceImpl extends ChatBotService{
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.domain.chatbot.dto.ChatRequestDto;
+import org.scoula.domain.chatbot.dto.ChatResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ChatBotServiceImpl implements ChatBotService{
+
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.api.url}")
+    private String openaiApiUrl;
+
+    @Value("${openai.model}")
+    private String model;
+
+    
+    // JSON <-> JAVA 변환
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public ChatResponseDto getChatResponse(ChatRequestDto request) {
+        try {
+            // 메시지 포맷 구성
+            Map<String, Object> message = new HashMap<>();
+            message.put("role", "user");
+            message.put("content", request.getMessage());
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("model", model);
+            body.put("messages", List.of(message));
+            body.put("temperature", 0.7);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openaiApiKey);
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<String> response = restTemplate.postForEntity(openaiApiUrl, entity, String.class);
+
+            JsonNode root = objectMapper.readTree(response.getBody());
+            String content = root.path("choices").get(0).path("message").path("content").asText();
+
+            return ChatResponseDto.builder()
+                    .content(content.trim())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("OpenAI 호출 중 오류 발생", e);
+            return ChatResponseDto.builder()
+                    .content("⚠ 오류가 발생했습니다. 다시 시도해주세요.")
+                    .build();
+        }
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-#jdbc.driver=com.mysql.cj.jdbc.Driver
-#jdbc.url=jdbc:mysql://127.0.0.1:3306/scoula_db
-jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/scoula_db
-jdbc.username=scoula
-jdbc.password=1234


### PR DESCRIPTION
### 🔍 작업 개요
- OpenAI GPT API 연동 및 기본 응답 기능 구현
- Postman을 통한 API 테스트 성공

### ✅ 변경 사항
(API 기본 응답을 위한)
- ChatRequestDto, ChatResponseDto 생성
- ChatBotController 구현
- ChatBotService 인터페이스 및 구현체 작성
- RestTemplate을 이용한 OpenAI API 연동

### 🧪 테스트 방법
- Postman으로 `/api/chat` 엔드포인트에 POST 요청 전송
- Request Body:
  ```json
  {
    "message": "애플 주식 어때?"
  }