### PR TITLE
refactor: chat bot/OpenAI client refactor

### DIFF
--- a/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
+++ b/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.scoula.util.chatbot.OpenAiClient;
 import org.scoula.util.chatbot.ProfileStockFilter;
 import org.scoula.api.mocktrading.VolumeRankingApi;
 import org.scoula.domain.chatbot.dto.*;
@@ -30,18 +31,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ChatBotServiceImpl implements ChatBotService {
 
-    private final RestTemplate restTemplate;
-
     private final PromptBuilder promptBuilder;
 
-    @Value("${openai.api.key}")
-    private String openaiApiKey;
-
-    @Value("${openai.api.url}")
-    private String openaiApiUrl;
-
-    @Value("${openai.api.model}")
-    private String model;
+    @Autowired
+    private OpenAiClient openAiClient;
 
     // 성향에 따른 종목 추천 유틸
     @Autowired
@@ -74,26 +67,7 @@ public class ChatBotServiceImpl implements ChatBotService {
                 String prompt = buildIntentClassificationPrompt(userMessage);
 
                 // GPT 호출
-                Map<String, Object> msg = new HashMap<>();
-                msg.put("role", "user");
-                msg.put("content", prompt);
-
-                Map<String, Object> requestBody = new HashMap<>();
-                requestBody.put("model", model);
-                requestBody.put("messages", List.of(msg));
-                requestBody.put("temperature", 0);
-
-                HttpHeaders headers = new HttpHeaders();
-                headers.setContentType(MediaType.APPLICATION_JSON);
-                headers.setBearerAuth(openaiApiKey);
-
-                HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
-
-
-                ResponseEntity<String> gptResponse = restTemplate.postForEntity(openaiApiUrl, entity, String.class);
-
-                JsonNode json = objectMapper.readTree(gptResponse.getBody());
-                String intentText = json.path("choices").get(0).path("message").path("content").asText().trim();
+                String intentText = openAiClient.getChatCompletion(prompt);
 
                 try {
                     intentType = IntentType.valueOf(intentText); // enum 파싱
@@ -199,10 +173,18 @@ public class ChatBotServiceImpl implements ChatBotService {
                             .map(ChatAnalysisMapper::toDto)
                             .toList();
 
-                    // 7. DB 저장 (선택사항)
+                    // 7. DB 저장 (추천된 종목의 데이터를 저장)
                     for (ChatAnalysisDto dto : analysisList) {
                         chatBotMapper.insertAnalysis(dto); // 직접 만든 insertAnalysis() 메서드
                     }
+
+                    // 8-1. GPT 분석 요청 프롬프트
+                    String analysisPrompt = promptBuilder.buildForStockInsights(analysisList);
+
+
+                    // 5,6 에서 저장된 추천 종목의 값을 gpt로 보내서 상세한 분석 요청
+                    // 분석 후 이유와 상세한 기술적 지표, 설명 등 응답 하게 만듦.
+                    // 추천한 이유를 DB에 저장(ChatRecommendationDto.reason)
 
                     // 8. GPT 프롬프트 구성
                     prompt = promptBuilder.buildForProfile(userId, summary, analysisList);
@@ -240,30 +222,7 @@ public class ChatBotServiceImpl implements ChatBotService {
                     log.info("🧠 GPT에 보낼 프롬프트:\n{}", prompt);
                     break;
             }
-            Map<String, Object> message = new HashMap<>();
-            message.put("role", "user");
-            message.put("content", prompt);
-
-            Map<String, Object> body = new HashMap<>();
-            body.put("model", model);
-            body.put("messages", List.of(message));
-            body.put("temperature", 0.6);
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            headers.setBearerAuth(openaiApiKey);
-
-            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
-            ResponseEntity<String> response = restTemplate.postForEntity(openaiApiUrl, entity, String.class);
-
-            // ====================== 6. 응답 성공 여부 확인 ======================
-            if (!response.getStatusCode().is2xxSuccessful()) {
-                return handleError(new RuntimeException("OpenAI 응답 실패 - 상태코드: " + response.getStatusCodeValue()), userId, intentType);
-            }
-
-            // ====================== 7. 응답 파싱 ======================
-            JsonNode root = objectMapper.readTree(response.getBody());
-            String content = root.path("choices").get(0).path("message").path("content").asText();
+            String content = openAiClient.getChatCompletion(prompt);
 
             // ====================== 8. GPT 응답 저장 ======================
             // chat_messages 테이블에 GPT 응답 저장

--- a/src/main/java/org/scoula/service/chatbot/PromptBuilder.java
+++ b/src/main/java/org/scoula/service/chatbot/PromptBuilder.java
@@ -8,6 +8,28 @@ import java.util.List;
 @Component
 public class PromptBuilder {
 
+    // 분석용 프롬프트
+    public String buildForStockInsights(List<ChatAnalysisDto> list) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("다음은 사용자의 투자 성향에 맞춰 선정된 종목들의 상세 데이터입니다.\n")
+                .append("아래 종목 데이터를 분석하여 종목별 투자 포인트와 리스크를 평가하고, 간단한 투자 의견을 작성하세요.\n")
+                .append("출력 형식은 반드시 JSON 배열로 하세요. 각 항목은 {\"ticker\":\"티커\", \"reason\":\"추천 사유\", \"riskLevel\":\"낮음/중간/높음\"} 입니다.\n\n");
+
+        for (ChatAnalysisDto s : list) {
+            sb.append("- ").append(s.getName())
+                    .append(" (").append(s.getTicker()).append(")\n")
+                    .append("  • 현재가: ").append(s.getPrice()).append("원\n")
+                    .append("  • PER: ").append(s.getPer()).append(", ROE: ").append(s.getRoe()).append(", EPS: ").append(s.getEps()).append("\n")
+                    .append("  • PBR: ").append(s.getPbr()).append(", 가중평균가: ").append(s.getAvgPrice()).append("\n")
+                    .append("  • 시가/고가/저가: ").append(s.getOpen()).append(" / ").append(s.getHigh()).append(" / ").append(s.getLow()).append("\n")
+                    .append("  • 52주 고가/저가: ").append(s.getHigh52w()).append(" / ").append(s.getLow52w()).append("\n")
+                    .append("  • 거래량: ").append(s.getVolume()).append(", 회전율: ").append(s.getTurnRate()).append("%, 외국인 보유율: ").append(s.getForeignRate()).append("%\n\n");
+        }
+
+        return sb.toString();
+    }
+
+
     // 투자 성향 기반 추천
     public String buildForProfile(Integer userId, String summary, List<ChatAnalysisDto> analysisList) {
         // analysisList 내용을 바탕으로 프롬프트 생성

--- a/src/main/java/org/scoula/util/chatbot/OpenAiClient.java
+++ b/src/main/java/org/scoula/util/chatbot/OpenAiClient.java
@@ -1,0 +1,53 @@
+package org.scoula.util.chatbot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiClient {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.api.url}")
+    private String openaiApiUrl;
+
+    @Value("${openai.api.model}")
+    private String model;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public String getChatCompletion(String prompt) {
+        try {
+            Map<String, Object> message = Map.of("role", "user", "content", prompt);
+            Map<String, Object> body = Map.of("model", model, "messages", List.of(message), "temperature", 0.6);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openaiApiKey);
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity(openaiApiUrl, entity, String.class);
+
+            JsonNode root = objectMapper.readTree(response.getBody());
+            return root.path("choices").get(0).path("message").path("content").asText().trim();
+
+        } catch (Exception e) {
+            throw new RuntimeException("OpenAI 호출 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
### 🔍 작업 개요
- OpenAI API 호출 로직 유틸 클래스로 분리 및 ChatBotServiceImpl 리팩토링

### ✅ 변경 사항
- OpenAiClient 유틸 클래스 생성 (RestTemplate, ObjectMapper 기반 GPT 호출 로직 분리)

- 기존 ChatBotServiceImpl의 GPT 호출 코드 제거 → openAiClient.getChatCompletion(prompt)로 대체


 종목 추천 이후 GPT 분석 프롬프트 호출까지 한 흐름으로 통합
### 🧪 테스트 방법
- GPT 응답이 DB (chat_messages, chat_analysis)에 정상 저장되는지 확인
- 로컬 서버 응답 확인

### 🔗 관련 이슈
- Close #123

### ✔️ 추가 사항

OpenAiClient는 향후 키워드 추천/포트폴리오 분석에서도 재사용 가능