### PR TITLE
fix: 성향 필터링 무시 및 중복 종목 조회 문제 해결 (volumeRanking 중복 제거 + 상세 조회 이후 필터링)

### DIFF
--- a/src/main/java/org/scoula/api/mocktrading/VolumeRankingApi.java
+++ b/src/main/java/org/scoula/api/mocktrading/VolumeRankingApi.java
@@ -155,6 +155,18 @@ public class VolumeRankingApi {
         combined.addAll(allMarkets.get("kospi"));
         combined.addAll(allMarkets.get("kosdaq"));
 
+        // 통합 랭킹 가져올 때 중복되게 가져오는 문제 해결
+        Map<String, Map<String, Object>> deduplicated = new LinkedHashMap<>();
+        for (Map<String, Object> stock : combined) {
+            String code = (String) stock.get("code");
+            if (!deduplicated.containsKey(code)) {
+                deduplicated.put(code, stock);
+            }
+        }
+
+        List<Map<String, Object>> uniqueStocks = new ArrayList<>(deduplicated.values());
+
+
         // 탭별 정렬 기준 적용
         combined.sort((a, b) -> {
             switch (blngClsCode) {

--- a/src/main/java/org/scoula/config/WebSocketInitializer.java
+++ b/src/main/java/org/scoula/config/WebSocketInitializer.java
@@ -13,6 +13,14 @@ public class WebSocketInitializer implements ServletContainerInitializer {
 
     @Override
     public void onStartup(Set<Class<?>> c, ServletContext servletContext) throws ServletException {
+
+        // sout 한글 깨짐 방지 설정
+        try {
+            System.setOut(new java.io.PrintStream(System.out, true, "UTF-8"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         ServerContainer serverContainer =
                 (ServerContainer) servletContext.getAttribute("javax.websocket.server.ServerContainer");
 

--- a/src/main/java/org/scoula/domain/chatbot/dto/RecommendationStock.java
+++ b/src/main/java/org/scoula/domain/chatbot/dto/RecommendationStock.java
@@ -12,19 +12,20 @@ import lombok.Data;
 public class RecommendationStock {
     private String code;
     private String name;
-    private String price;
-    private String per;
-    private String eps;
-    private String pbr;
-    private String open;
-    private String high;
-    private String low;
-    private String volume;
-    private String avgPrice;
-    private String foreignRate;
-    private String turnRate;
-    private String high52w;
-    private String low52w;
+    private Double price;
+    private Double per;
+    private Double eps;
+    private Double roe;
+    private Double pbr;
+    private Double open;
+    private Double high;
+    private Double low;
+    private Double volume;
+    private Double avgPrice;
+    private Double foreignRate;
+    private Double turnRate;
+    private Double high52w;
+    private Double low52w;
 
 
     // GPT나 내부 계산에서 나오는 예상 수익률, 리스크 정도

--- a/src/main/java/org/scoula/service/chatbot/ProfileStockRecommender.java
+++ b/src/main/java/org/scoula/service/chatbot/ProfileStockRecommender.java
@@ -2,6 +2,7 @@ package org.scoula.service.chatbot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.scoula.api.mocktrading.PriceApi;
 import org.scoula.domain.chatbot.dto.ChatPriceResponse;
 import org.scoula.domain.chatbot.dto.RecommendationStock;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
-
+@Log4j2
 @Component
 @RequiredArgsConstructor
 public class ProfileStockRecommender {
@@ -18,45 +19,70 @@ public class ProfileStockRecommender {
     private final ObjectMapper objectMapper;
 
     public List<RecommendationStock> getRecommendedStocksByProfile(List<String> tickers, List<String> names) {
+
+        log.info("✅ tickers.size = {}, names.size = {}", tickers.size(), names.size());
+        log.info("✅ tickers: {}", tickers);
+        log.info("✅ names: {}", names);
         List<RecommendationStock> stocks = new ArrayList<>();
+
+
 
         for (int i = 0; i < tickers.size(); i++) {
             String ticker = tickers.get(i);
             String name = names.get(i);
 
             try {
+                log.info("🔎 종목 상세 조회 요청 → {} ({})", name, ticker);
+
+                var raw = PriceApi.getPriceData(ticker);
+                log.info("🧾 -----------price raw response for {}: {}", ticker, raw.toPrettyString());
+
+
                 ChatPriceResponse response = objectMapper.treeToValue(
                         PriceApi.getPriceData(ticker), ChatPriceResponse.class
                 );
 
                 RecommendationStock stock = toRecommendationStock(name, ticker,response.getOutput());
                 stocks.add(stock);
+                log.info("✅ 상세 데이터 변환 완료 → {} ({})", name, ticker);
+
 
             } catch (Exception e) {
-                System.err.println("❌ " + ticker + " 데이터 조회 실패: " + e.getMessage());
+                log.warn("❌ 상세 종목 조회 실패 - {}({}): {}", name, ticker, e.getMessage());
             }
         }
 
+        log.info("📊 최종 상세 종목 수: {} / {}", stocks.size(), tickers.size());
         return stocks;
+
     }
 
-    private RecommendationStock toRecommendationStock(String name,String code, ChatPriceResponse.Output o) {
+    private RecommendationStock toRecommendationStock(String name, String code, ChatPriceResponse.Output o) {
         return RecommendationStock.builder()
                 .name(name)
                 .code(code)
-                .price(o.getStck_prpr())
-                .per(o.getPer())
-                .eps(o.getEps())
-                .pbr(o.getPbr())
-                .open(o.getStck_oprc())
-                .high(o.getStck_hgpr())
-                .low(o.getStck_lwpr())
-                .volume(o.getAcml_vol())
-                .avgPrice(o.getWghn_avrg_stck_prc())
-                .foreignRate(o.getHts_frgn_ehrt())
-                .turnRate(o.getVol_tnrt())
-                .high52w(o.getD250_hgpr())
-                .low52w(o.getD250_lwpr())
+                .price(parseDouble(o.getStck_prpr()))
+                .per(parseDouble(o.getPer()))
+                .eps(parseDouble(o.getEps()))
+                .pbr(parseDouble(o.getPbr()))
+                .open(parseDouble(o.getStck_oprc()))
+                .high(parseDouble(o.getStck_hgpr()))
+                .low(parseDouble(o.getStck_lwpr()))
+                .volume(parseDouble(o.getAcml_vol()))
+                .avgPrice(parseDouble(o.getWghn_avrg_stck_prc()))
+                .foreignRate(parseDouble(o.getHts_frgn_ehrt()))
+                .turnRate(parseDouble(o.getVol_tnrt()))
+                .high52w(parseDouble(o.getD250_hgpr()))
+                .low52w(parseDouble(o.getD250_lwpr()))
                 .build();
+    }
+
+    private Double parseDouble(String str) {
+        try {
+            return (str == null || str.isBlank()) ? null : Double.parseDouble(str.replace(",", ""));
+        } catch (NumberFormatException e) {
+            log.warn("❗ 숫자 변환 실패: '{}'", str);
+            return null;
+        }
     }
 }

--- a/src/main/java/org/scoula/util/chatbot/ChatAnalysisMapper.java
+++ b/src/main/java/org/scoula/util/chatbot/ChatAnalysisMapper.java
@@ -11,23 +11,23 @@ public class ChatAnalysisMapper {
 
         System.out.println("🧪 stock code: " + stock.getCode());
         return ChatAnalysisDto.builder()
-                .ticker(stock.getCode())// 추출하거나 매핑 로직 있어야 함
+                .ticker(stock.getCode())
                 .name(stock.getName())
-                .region("KR") // 기본값, 조건에 따라 US 넣을 수 있음
-                .per(parseFloat(stock.getPer()))
-                .roe(null) // 따로 데이터 없으면 일단 null
-                .eps(parseFloat(stock.getEps()))
-                .price(parseFloat(stock.getPrice()))
-                .pbr(parseFloat(stock.getPbr()))
-                .open(parseFloat(stock.getOpen()))
-                .high(parseFloat(stock.getHigh()))
-                .low(parseFloat(stock.getLow()))
-                .volume(parseLong(stock.getVolume()))
-                .avgPrice(parseFloat(stock.getAvgPrice()))
-                .foreignRate(parseFloat(stock.getForeignRate()))
-                .turnRate(parseFloat(stock.getTurnRate()))
-                .high52w(parseFloat(stock.getHigh52w()))
-                .low52w(parseFloat(stock.getLow52w()))
+                .region("KR")
+                .per(toFloat(stock.getPer()))
+                .roe(null)
+                .eps(toFloat(stock.getEps()))
+                .price(toFloat(stock.getPrice()))
+                .pbr(toFloat(stock.getPbr()))
+                .open(toFloat(stock.getOpen()))
+                .high(toFloat(stock.getHigh()))
+                .low(toFloat(stock.getLow()))
+                .volume(toLong(stock.getVolume()))
+                .avgPrice(toFloat(stock.getAvgPrice()))
+                .foreignRate(toFloat(stock.getForeignRate()))
+                .turnRate(toFloat(stock.getTurnRate()))
+                .high52w(toFloat(stock.getHigh52w()))
+                .low52w(toFloat(stock.getLow52w()))
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
@@ -46,5 +46,13 @@ public class ChatAnalysisMapper {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private static Float toFloat(Double value) {
+        return value == null ? null : value.floatValue();
+    }
+
+    private static Long toLong(Double value) {
+        return value == null ? null : value.longValue();
     }
 }

--- a/src/main/java/org/scoula/util/chatbot/ProfileStockFilter.java
+++ b/src/main/java/org/scoula/util/chatbot/ProfileStockFilter.java
@@ -1,52 +1,70 @@
-package org.scoula.util.chatbot;
+    package org.scoula.util.chatbot;
 
-import org.scoula.domain.chatbot.dto.RecommendationStock;
+    import lombok.extern.log4j.Log4j2;
+    import org.scoula.domain.chatbot.dto.RecommendationStock;
 
-import java.util.List;
-import java.util.stream.Collectors;
+    import java.util.List;
+    import java.util.stream.Collectors;
 
-public class ProfileStockFilter {
+    @Log4j2
+    public class ProfileStockFilter {
 
-    public static List<RecommendationStock> filterByRiskType(String riskType, List<RecommendationStock> stocks) {
-        return stocks.stream()
-                .filter(stock -> isMatch(riskType, stock))
-                .collect(Collectors.toList());
-    }
 
-    public static boolean isMatch(String riskType, RecommendationStock stock) {
-        switch (riskType) {
-            case "AGR": // 적극적 성장형
-            case "DTA": // 단타 추구형
-            case "THE": // 테마 투자형
-                return parseFloat(stock.getTurnRate()) != null &&
-                        parseFloat(stock.getTurnRate()) > 2.0;
+        public static List<RecommendationStock> filterByRiskType(String riskType, List<RecommendationStock> stocks) {
+            return stocks.stream()
+                    .filter(stock -> isMatch(riskType, stock))
+                    .collect(Collectors.toList());
+        }
 
-            case "VAL": // 가치 투자형
-                return parseFloat(stock.getPer()) != null && parseFloat(stock.getPer()) < 10 &&
-                        parseFloat(stock.getPbr()) != null && parseFloat(stock.getPbr()) < 1.2;
+        public static boolean isMatch(String riskType, RecommendationStock stock) {
+            Float per = toFloat(stock.getPer());
+            Float pbr = toFloat(stock.getPbr());
+            Float volume = toFloat(stock.getVolume());
+            Float turnRate = toFloat(stock.getTurnRate());
 
-            case "TEC": // 기술적 분석형
-                return parseFloat(stock.getVolume()) != null && parseFloat(stock.getVolume()) > 1000000;
+            log.info("🧪 [{}] per={}, pbr={}, volume={}, turnRate={}", riskType, per, pbr, volume, turnRate);
+            log.info("🧪 [{}] 종목={}, 원본 per={}, 원본 pbr={}, 원본 volume={}, 원본 turnRate={}",
+                    riskType, stock.getName(), stock.getPer(), stock.getPbr(), stock.getVolume(), stock.getTurnRate());
 
-            case "IND": // 인덱스 수동형
-            case "CSD": // 신중한 안정형
-                return false;
+            switch (riskType) {
+                case "AGR": // 적극적 성장형
+                case "DTA": // 단타 추구형
+                case "THE": // 테마 투자형
+                    return turnRate != null && turnRate > 1.0;
 
-            case "INF": // 정보 수집형
-            case "SYS": // 시스템 트레이더형
-                return parseFloat(stock.getPer()) != null && parseFloat(stock.getPer()) < 30 &&
-                        parseFloat(stock.getTurnRate()) != null && parseFloat(stock.getTurnRate()) > 0.5;
+                case "VAL": // 가치 투자형
+                    return per != null && per < 15 &&
+                            pbr != null && pbr < 1.5;
 
-            default:
-                return true;
+                case "TEC": // 기술적 분석형
+                    return volume != null && volume > 500_000;
+
+                case "IND": // 인덱스 수동형
+                case "CSD": // 신중한 안정형
+                    return per != null && per < 20 &&
+                            pbr != null && pbr < 2.0 &&
+                            turnRate != null && turnRate > 0.3;
+
+                case "INF": // 정보 수집형
+                case "SYS": // 시스템 트레이더형
+                    return per != null && per < 40 &&
+                            turnRate != null && turnRate > 0.2;
+
+                default:
+                    return true;
+            }
+        }
+
+        private static Float parseFloat(String val) {
+            try {
+                if (val == null || val.isBlank() || val.equalsIgnoreCase("null")) return null;
+                return Float.parseFloat(val.replace(",", ""));
+            } catch (Exception e) {
+                log.warn("⚠️ parseFloat 실패 → val: {}", val);
+                return null;
+            }
+        }
+        private static Float toFloat(Double val) {
+            return val == null ? null : val.floatValue();
         }
     }
-
-    private static Float parseFloat(String val) {
-        try {
-            return val == null || val.isBlank() ? null : Float.parseFloat(val.replace(",", ""));
-        } catch (Exception e) {
-            return null;
-        }
-    }
-}

--- a/src/main/java/org/scoula/util/chatbot/ProfileStockMapper.java
+++ b/src/main/java/org/scoula/util/chatbot/ProfileStockMapper.java
@@ -11,23 +11,33 @@ public class ProfileStockMapper {
         return RecommendationStock.builder()
                 .name((String) map.get("name"))
                 .code((String) map.get("code"))
-                .price(toNullableString(map.get("currentPrice")))
-                .turnRate(toNullableString(map.get("turnoverRate")))
-                .per(toNullableString(map.get("per")))
-                .pbr(toNullableString(map.get("pbr")))
-                .eps(toNullableString(map.get("eps")))
-                .volume(toNullableString(map.get("volume")))
-                .avgPrice(toNullableString(map.get("avgPrice")))
-                .foreignRate(toNullableString(map.get("foreignRate")))
-                .high(toNullableString(map.get("high")))
-                .low(toNullableString(map.get("low")))
-                .open(toNullableString(map.get("open")))
-                .high52w(toNullableString(map.get("high52w")))
-                .low52w(toNullableString(map.get("low52w")))
+                .price(toNullableDouble(map.get("currentPrice")))
+                .turnRate(toNullableDouble(map.get("turnoverRate")))
+                .per(toNullableDouble(map.get("per")))
+                .pbr(toNullableDouble(map.get("pbr")))
+                .eps(toNullableDouble(map.get("eps")))
+                .volume(toNullableDouble(map.get("volume")))
+                .avgPrice(toNullableDouble(map.get("avgPrice")))
+                .foreignRate(toNullableDouble(map.get("foreignRate")))
+                .high(toNullableDouble(map.get("high")))
+                .low(toNullableDouble(map.get("low")))
+                .open(toNullableDouble(map.get("open")))
+                .high52w(toNullableDouble(map.get("high52w")))
+                .low52w(toNullableDouble(map.get("low52w")))
                 .build();
     }
 
     private static String toNullableString(Object value) {
         return (value == null || value.toString().isBlank()) ? null : value.toString();
     }
+
+    private static Double toNullableDouble(Object value) {
+        try {
+            if (value == null || value.toString().isBlank()) return null;
+            return Double.parseDouble(value.toString().replace(",", ""));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
### 🔍 작업 개요
- 간단한 설명 (어떤 기능/작업인지)

### ✅ 변경 사항
- 상세 정보 조회 이전에 필터링을 수행하여 조건에 맞는 종목이 없던 문제 해결
  → 상세 정보 먼저 조회 후 ProfileStockFilter로 필터링 수행

- volumeRankingApi 통합 조회 결과에서 동일 종목(code 기준)이 중복되어
  getRecommendedStocksByProfile에서 동일 종목을 2번씩 조회하던 문제 해결
  → getCombinedVolumeRanking에서 중복 제거 처리 추가 (LinkedHashMap 사용)

- 프론트 전달 전 recStocks 리스트에서도 중복 제거 처리 추가

- WebSocketInitializer의 System.out 한글 깨짐 현상 해결 (PrintStream UTF-8 적용)
- 
### 🧪 테스트 방법
- DB 확인
- 서버 응답/ LOG 확인

### 🔗 관련 이슈
-

### ✔️ 추가 사항