### PR TITLE
Refactor/chat bot/service

### DIFF
--- a/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
+++ b/src/main/java/org/scoula/service/chatbot/ChatBotServiceImpl.java
@@ -8,7 +8,6 @@ import lombok.extern.log4j.Log4j2;
 import org.scoula.domain.trading.dto.TransactionDTO;
 import org.scoula.service.trading.TradingService;
 import org.scoula.util.chatbot.*;
-import org.scoula.util.chatbot.*;
 import org.scoula.api.mocktrading.VolumeRankingApi;
 import org.scoula.domain.chatbot.dto.*;
 import org.scoula.domain.chatbot.enums.ErrorType;
@@ -16,10 +15,7 @@ import org.scoula.domain.chatbot.enums.ErrorType;
 import org.scoula.domain.chatbot.enums.IntentType;
 import org.scoula.mapper.chatbot.ChatBotMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 
 import java.io.IOException;
@@ -36,25 +32,11 @@ import java.util.stream.Collectors;
 public class ChatBotServiceImpl implements ChatBotService {
 
     private final PromptBuilder promptBuilder;
-
-    @Autowired
-    private OpenAiClient openAiClient;
-
-    // 성향에 따른 종목 추천 유틸
-    @Autowired
-    private ProfileStockRecommender profileStockRecommender;
-
-    // 모의투자팀이 열심히 만든~ 볼륨랭킹
-    @Autowired
-    private VolumeRankingApi volumeRankingApi;
-
-    @Autowired
-    private UserProfileService userProfileService;
-
-    @Autowired
-    private StockNameParser stockNameParser;
-
-    // 쳇봇 mapper 주입
+    private final OpenAiClient openAiClient;
+    private final ProfileStockRecommender profileStockRecommender;
+    private final VolumeRankingApi volumeRankingApi;
+    private final UserProfileService userProfileService;
+    private final StockNameParser stockNameParser;
     private final ChatBotMapper chatBotMapper;
     private final ObjectMapper objectMapper;
     private final TradingService tradingService;

--- a/src/main/java/org/scoula/service/chatbot/intent/IntentResolver.java
+++ b/src/main/java/org/scoula/service/chatbot/intent/IntentResolver.java
@@ -1,0 +1,36 @@
+package org.scoula.service.chatbot.intent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.domain.chatbot.enums.IntentType;
+import org.scoula.service.chatbot.PromptBuilder;
+import org.scoula.util.chatbot.OpenAiClient;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class IntentResolver {
+
+    private final OpenAiClient openAiClient;
+    private final PromptBuilder promptBuilder;
+
+    // 프론트가 intent를 주면 그대로 사용. 없거나 MESSAGE면 GPT로 분류
+    public IntentType resolve(String userMessage, IntentType incoming) {
+        if (incoming != null && incoming != IntentType.MESSAGE) {
+            log.info("[INTENT] 프론트 지정 → {}", incoming);
+            return incoming;
+        }
+        String prompt = promptBuilder.buildIntentClassificationPrompt(userMessage);
+        String intentText = openAiClient.getChatCompletion(prompt);
+        try {
+            IntentType resolved = IntentType.valueOf(intentText);
+            log.info("[INTENT] GPT 분류 → {}", resolved);
+            return resolved;
+        } catch (IllegalArgumentException ex) {
+            log.warn("[INTENT] GPT 응답을 enum으로 파싱 실패: {}", intentText);
+            return IntentType.UNKNOWN;
+        }
+    }
+
+}

--- a/src/main/java/org/scoula/service/chatbot/message/MessageService.java
+++ b/src/main/java/org/scoula/service/chatbot/message/MessageService.java
@@ -1,0 +1,31 @@
+package org.scoula.service.chatbot.message;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.domain.chatbot.dto.ChatMessageDto;
+import org.scoula.domain.chatbot.enums.IntentType;
+import org.scoula.mapper.chatbot.ChatBotMapper;
+import org.springframework.stereotype.Service;
+
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+    private final ChatBotMapper chatBotMapper;
+
+    // 메세지 저장 함수
+    public ChatMessageDto save(Integer userId, Integer sessionId, String role, String content, IntentType intentType) {
+        ChatMessageDto message = ChatMessageDto.builder()
+                .userId(userId)
+                .sessionId(sessionId)
+                .role(role)
+                .content(content)
+                .intentType(intentType)
+                .build();
+
+        chatBotMapper.insertChatMessage(message); // insert 시 keyProperty="id"로 id 채워짐
+        log.info("[MESSAGE] 저장 완료 → id={}", message.getId());
+        return message; // ID 포함된 message 반환
+    }
+}

--- a/src/main/java/org/scoula/service/chatbot/session/ChatSessionService.java
+++ b/src/main/java/org/scoula/service/chatbot/session/ChatSessionService.java
@@ -1,0 +1,59 @@
+package org.scoula.service.chatbot.session;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.domain.chatbot.dto.ChatSessionDto;
+import org.scoula.domain.chatbot.enums.IntentType;
+import org.scoula.mapper.chatbot.ChatBotMapper;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ChatSessionService {
+
+    private final ChatBotMapper chatBotMapper;
+
+    /** 세션 없으면 생성, intent 바뀌면 종료 후 새로 생성, 같으면 갱신 */
+    public Integer ensureSession(Integer userId, Integer sessionId, IntentType currentIntent) {
+        if (sessionId == null) {
+            ChatSessionDto newSession = ChatSessionDto.builder()
+                    .userId(userId)
+                    .lastIntent(currentIntent)
+                    .build();
+            chatBotMapper.insertChatSession(newSession);
+            log.info("[SESSION] 새 세션 생성 → id={}, intent={}", newSession.getId(), currentIntent);
+            return newSession.getId();
+        }
+
+        IntentType lastIntent = chatBotMapper.getLastIntentBySessionId(sessionId);
+        if (lastIntent == null || !currentIntent.equals(lastIntent)) {
+            chatBotMapper.endChatSession(sessionId);
+            log.info("[SESSION] intent 변경 → 기존 세션 종료: {}", sessionId);
+
+            ChatSessionDto newSession = ChatSessionDto.builder()
+                    .userId(userId)
+                    .lastIntent(currentIntent)
+                    .build();
+            chatBotMapper.insertChatSession(newSession);
+            log.info("[SESSION] 새 세션 생성 → id={}, intent={}", newSession.getId(), currentIntent);
+            return newSession.getId();
+        }
+
+        // intent 동일 → 갱신만
+        chatBotMapper.updateChatSessionIntent(ChatSessionDto.builder()
+                .id(sessionId).lastIntent(currentIntent).build());
+        log.info("[SESSION] intent 동일 → 세션 갱신: {}", sessionId);
+        return sessionId;
+    }
+
+    /** 에러 발생 시 활성 세션 종료*/
+    public void endActiveSessionIfAny(Integer userId) {
+        Integer activeSessionId = chatBotMapper.getActiveSessionIdByUserId(userId);
+        if (activeSessionId != null) {
+            chatBotMapper.endChatSession(activeSessionId);
+            log.info("❌ 에러로 세션 종료: {}", activeSessionId);
+        }
+    }
+}


### PR DESCRIPTION
### 🔍 작업 개요
- 의도 분류 로직 IntentResolver로 분리

- 메시지 저장 로직 MessageService로 분리

- 세션 관리 ChatSessionService로 위임 (기존 if/else 제거)

- PORTFOLIO_ANALYZE 케이스의 중복 메시지 저장 제거 및 messageId 연계 안정화



### ✅ 변경 사항
 IntentResolver 도입: 프론트가 intent 주면 스킵, 없거나 MESSAGE면 GPT로 분류

 MessageService.save(...) 추가: saveChatMessage 제거, 메시지 기록 책임 단일화

 ChatSessionService.ensureSession(...) 적용: 세션 생성/종료/갱신 로직 서비스로 이전

 PORTFOLIO_ANALYZE에서 어시스턴트 메시지 한 번만 저장하고, 해당 messageId로 ChatBehaviorFeedback 연계

 handleError(...)에서 세션 종료를 chatSessionService.endActiveSessionIfAny(...)로 위임

 불필요한 @Autowired 및 미사용 import 제거, 생성자 주입 통일



### 🧪 테스트 방법

의도 분류

요청: "내 거래 습관 분석해줘 (3개월)"

기대: IntentResolver가 PORTFOLIO_ANALYZE로 분류, 세션 생성 로그 확인

메시지 저장 단일화

아무 질문: MESSAGE → 1회만 chat_messages에 저장되는지 DB/로그 확인

포트폴리오 분석 흐름

요청: "지난 3개월 투자 피드백"

기대:

assistant 메시지 1건 저장

생성된 message_id가 chat_behavior_feedback.message_id에 연동

관련 거래내역 연결 테이블(chat_behavior_feedback_transaction)에 N건 insert

세션 전환

연속 요청: RECOMMEND_KEYWORD → TERM_EXPLAIN

기대: 기존 세션 종료 + 새 세션 생성 로그 확인

에러 핸들링

OpenAI 강제 에러(모킹/토큰 제한 등) → handleError 동작 및 활성 세션 종료 위임 로그 확인



### 🔗 관련 이슈

### ✔️ 추가 사항